### PR TITLE
Add autoAnswer parameter to originatecall request

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ This project provides a small command line dialer that triggers calls through th
 ```
 python dialer.py <phone_number>
 ```
-The script sends a request to `https://vpbx.me/api/originatecall/<phone_number>/<extension>` using your API key and extension
-from `config.json`. The `<phone_number>` argument can be a plain number or a `tel:` link such as `tel:+123456789`.
+The script sends a request to `https://vpbx.me/api/originatecall/<extension>/<phone_number>?autoAnswer=true` using your API
+key and extension from `config.json`. The `<phone_number>` argument can be a plain number or a `tel:` link such as
+`tel:+123456789`.
 
 ## Building a Windows executable
 The project can be bundled with [PyInstaller](https://www.pyinstaller.org/):

--- a/dialer.py
+++ b/dialer.py
@@ -37,7 +37,8 @@ def make_call(api_key: str, extension: str, number: str) -> str:
         "Content-Type": "application/json",
         "X-Api-Key": api_key,
     }
-    response = requests.get(url, headers=headers)
+    params = {"autoAnswer": "true"}
+    response = requests.get(url, headers=headers, params=params)
     response.raise_for_status()
     return response.text
 


### PR DESCRIPTION
## Summary
- enable automatic answer on originatecall requests
- document new request URL and parameter

## Testing
- `python -m py_compile dialer.py`
- `python dialer.py 123` (fails due to missing config as expected)


------
https://chatgpt.com/codex/tasks/task_e_68c7f39d347c832eb6d176abce7b2cce