### PR TITLE
Include timeout parameter in dialer request

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project provides a small command line dialer that triggers calls through th
 ```
 python dialer.py <phone_number>
 ```
-The script sends a request to `https://vpbx.me/api/originatecall/<extension>/<phone_number>?autoAnswer=true` using your API
+The script sends a request to `https://vpbx.me/api/originatecall/<extension>/<phone_number>?timeout=20&autoAnswer=true` using your API
 key and extension from `config.json`. The `<phone_number>` argument can be a plain number or a `tel:` link such as
 `tel:+123456789`.
 

--- a/dialer.py
+++ b/dialer.py
@@ -37,7 +37,7 @@ def make_call(api_key: str, extension: str, number: str) -> str:
         "Content-Type": "application/json",
         "X-Api-Key": api_key,
     }
-    params = {"autoAnswer": "true"}
+    params = {"timeout": 20, "autoAnswer": "true"}
     response = requests.get(url, headers=headers, params=params)
     response.raise_for_status()
     return response.text


### PR DESCRIPTION
## Summary
- Add `timeout=20` query parameter alongside `autoAnswer=true` when originating calls
- Update documentation to reflect full request URL

## Testing
- `python -m pytest` (no tests found)
- `python -m py_compile dialer.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7f6608488832eb99ef2178586de74