### PR TITLE
Fix auto answer parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project provides a small command line dialer that triggers calls through th
 ```
 python dialer.py <phone_number>
 ```
-The script sends a request to `https://vpbx.me/api/originatecall/<extension>/<phone_number>?timeout=20&autoAnswer=true` using your API
+The script sends a request to `https://vpbx.me/api/originatecall/<extension>/<phone_number>?timeout=20&autoanswer=true` using your API
 key and extension from `config.json`. The `<phone_number>` argument can be a plain number or a `tel:` link such as
 `tel:+123456789`.
 

--- a/dialer.py
+++ b/dialer.py
@@ -37,7 +37,10 @@ def make_call(api_key: str, extension: str, number: str) -> str:
         "Content-Type": "application/json",
         "X-Api-Key": api_key,
     }
-    params = {"timeout": 20, "autoAnswer": "true"}
+    # Older documentation used the camelCase ``autoAnswer`` parameter, but the
+    # API expects a lowercase ``autoanswer`` flag for enabling automatic
+    # answering on compatible terminals.
+    params = {"timeout": 20, "autoanswer": "true"}
     response = requests.get(url, headers=headers, params=params)
     response.raise_for_status()
     return response.text


### PR DESCRIPTION
## Summary
- Use lowercase `autoanswer` query parameter when initiating calls
- Update documentation to match the new parameter name

## Testing
- `python -m py_compile dialer.py`
- `python dialer.py 123` (fails: Missing config.json)


------
https://chatgpt.com/codex/tasks/task_e_68c7f9fed5e4832eab9461b538cab0d7